### PR TITLE
Increase Timeout in Example Node

### DIFF
--- a/interactive_geometry_examples/src/interactive_ellipsoid_client_node.cpp
+++ b/interactive_geometry_examples/src/interactive_ellipsoid_client_node.cpp
@@ -30,7 +30,7 @@ int main (int argc, char **argv)
   ac.sendGoal(goal);
 
   //wait for the action to return
-  bool finished_before_timeout = ac.waitForResult(ros::Duration(30.0));
+  bool finished_before_timeout = ac.waitForResult(ros::Duration(300.0));
 
   if (finished_before_timeout)
   {


### PR DESCRIPTION
A time of 30s is a little low - sometimes this triggers before you are done.  This commit increases the timeout to 300s (5min).