### PR TITLE
Fix/improve subsequent calls

### DIFF
--- a/interactive_geometry/CMakeLists.txt
+++ b/interactive_geometry/CMakeLists.txt
@@ -89,37 +89,23 @@ include_directories(
 ## Install ##
 #############
 
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
 install(PROGRAMS
      scripts/ellipsoid_generator
      src/interactive_ellipsoid_node
+     src/interactive_ellipsoid_server_node
      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+  PATTERN ".svn" EXCLUDE
+)
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+install(FILES rviz/config.rviz
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz
+)
 
 #############
 ## Testing ##

--- a/interactive_geometry/src/interactive_ellipsoid_node
+++ b/interactive_geometry/src/interactive_ellipsoid_node
@@ -136,6 +136,7 @@ if __name__ == '__main__':
             exporter.mesh_to_stl(gen.vertices, gen.faces, filename)
             util.save_file = False
             print("Exported mesh as " + filename)
+            break;
 
         # Publish the mesh
         pub_marker.publish(marker)

--- a/interactive_geometry/src/interactive_ellipsoid_server_node
+++ b/interactive_geometry/src/interactive_ellipsoid_server_node
@@ -50,13 +50,23 @@ class EllipsoidAction(object):
     _result = interactive_geometry_msgs.msg.InteractiveEllipsoidResult()
 
     def __init__(self, name):
+        # Mesh publisher
+        self._pub_marker = rospy.Publisher('mesh_marker', Marker, queue_size=10)
+
+        # Set Marker server and TF
+        self._server = InteractiveMarkerServer("basic_controls")
+        self._broadcaster = TransformBroadcaster()
+        self._listener = TransformListener()
+
+        # Utilities class for manipulating interactive marker
+        self._util = InteractiveMarkerUtils(self._server, self._broadcaster, self._pub_marker)
+
         # Setup action server
         self._action_name = name
         self._as = actionlib.SimpleActionServer(self._action_name, interactive_geometry_msgs.msg.InteractiveEllipsoidAction, execute_cb=self.execute_cb, auto_start = False)
         self._as.start()
 
     def execute_cb(self, goal):
-        pub_marker = rospy.Publisher('mesh_marker', Marker, queue_size=10)
 
         # Read ROS parameters
         global_vars.a_scale = rospy.get_param('~a', 1.0)
@@ -69,45 +79,39 @@ class EllipsoidAction(object):
         parent_link = goal.parent_link
         mesh_link = goal.mesh_link
 
-        # Set Marker server and TF
-        server = InteractiveMarkerServer("basic_controls")
-        broadcaster = TransformBroadcaster()
-        listener = TransformListener()
-
         # Set up generation utilities
-        util = InteractiveMarkerUtils(server, broadcaster, pub_marker)
-        util.parent_link = parent_link
-        util.mesh_link = mesh_link
+        self._util.parent_link = parent_link
+        self._util.mesh_link = mesh_link
         exporter = MeshExporter()
 
         # Make central control to move mesh
         position = Point(0, 0, 0)
-        util.make6DofMarker(False, InteractiveMarkerControl.MOVE_3D, position, True)
-        server.applyChanges()
+        self._util.make6DofMarker(False, InteractiveMarkerControl.MOVE_3D, position, True)
+        self._server.applyChanges()
 
         # Make controls to resize mesh (positive direction)
         position = Point(global_vars.a_scale, 0,  0)
-        util.makeMovingMarker( position, "a", axis=0)
+        self._util.makeMovingMarker( position, "a", axis=0)
         position = Point(0, global_vars.b_scale,  0)
-        util.makeMovingMarker( position, "b", axis=1)
+        self._util.makeMovingMarker( position, "b", axis=1)
         position = Point(0, 0, global_vars.c_scale)
-        util.makeMovingMarker( position, "c", axis=2)
+        self._util.makeMovingMarker( position, "c", axis=2)
 
         # Make controls to resize mesh (negative directon)
         position = Point(-1*global_vars.a_scale, 0,  0)
-        util.makeMovingMarker( position, "a_neg", axis=0)
+        self._util.makeMovingMarker( position, "a_neg", axis=0)
         position = Point(0, 0, -1*global_vars.c_scale)
-        util.makeMovingMarker( position, "c_neg", axis=2)
+        self._util.makeMovingMarker( position, "c_neg", axis=2)
 
         # 'commit' changes and send to all clients
-        server.applyChanges()
+        self._server.applyChanges()
 
         # Generate the initial ellipsoid
         gen = EllipsoidGenerator(global_vars.a_scale, global_vars.b_scale, global_vars.c_scale, num_pts)
         gen.generate_ellipsoid()
 
         # Setup for loop
-        broadcaster.sendTransform( (0, 0, 0), (0, 0, 0, 1.0), rospy.Time.now(), parent_link, mesh_link )
+        self._broadcaster.sendTransform( (0, 0, 0), (0, 0, 0, 1.0), rospy.Time.now(), parent_link, mesh_link )
         rate = rospy.Rate(30) # 30hz
         seq = 0
         finished = False
@@ -118,10 +122,10 @@ class EllipsoidAction(object):
 
             # Rebroadcast the tf
             try:
-                (trans,rot) = listener.lookupTransform(parent_link, mesh_link, rospy.Time(0))
-                broadcaster.sendTransform( trans, rot, rospy.Time.now(), mesh_link, parent_link,)
+                (trans,rot) = self._listener.lookupTransform(parent_link, mesh_link, rospy.Time(0))
+                self._broadcaster.sendTransform( trans, rot, rospy.Time.now(), mesh_link, parent_link,)
             except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
-                broadcaster.sendTransform( (0, 0, 0), (0, 0, 0, 1.0), rospy.Time.now(),  mesh_link, parent_link )
+                self._broadcaster.sendTransform( (0, 0, 0), (0, 0, 0, 1.0), rospy.Time.now(),  mesh_link, parent_link )
                 print("Resetting TF")
                 continue
 
@@ -131,9 +135,9 @@ class EllipsoidAction(object):
             marker.header.stamp = rospy.Time.now()
 
             # Save mesh if button clicked
-            if util.save_file == True:
+            if self._util.save_file == True:
                 exporter.mesh_to_stl(gen.vertices, gen.faces, filename)
-                util.save_file = False
+                self._util.save_file = False
                 print("Exported mesh as " + filename)
                 self._result.results_path = filename
                 self._result.success = True
@@ -142,7 +146,11 @@ class EllipsoidAction(object):
 
 
             # Publish the mesh
-            pub_marker.publish(marker)
+            self._pub_marker.publish(marker)
+
+        # Hide the controls, but leave the mesh showing
+        self._server.clear()
+        self._server.applyChanges()
 
 
 

--- a/interactive_geometry/src/interactive_geometry/global_vars.py
+++ b/interactive_geometry/src/interactive_geometry/global_vars.py
@@ -1,6 +1,8 @@
 """ Contains the global variables needed by this package.
 
 I know this is probably bad practice. Shoot me.
+
+*Bang*
 """
 
 

--- a/interactive_geometry/src/interactive_geometry/interactive_marker_utils.py
+++ b/interactive_geometry/src/interactive_geometry/interactive_marker_utils.py
@@ -63,7 +63,7 @@ class InteractiveMarkerUtils:
         self.pub_marker = pub
         self.server = serv
         self.br = broadcaster
-        self.menu_handler.insert( "Export mesh as STL", callback=self.menuCallback1)
+        self.menu_handler.insert( "Export mesh as STL", callback=self.menuCallback1 )
         self.menu_handler.insert( "Do something else!", callback=self.menuCallback2 )
 
     def menuCallback1(self, feedback):


### PR DESCRIPTION
The server node seemed to have some difficulty with subsequent action calls.  The first one works fine.  After that, and especially after a second call is made, the interactive marker controls begin blinking and are difficult to use.  This PR makes the interactive marker controls (but not the mesh) go away after every action call, and come back new.  This seems to improve behavior.

The third and fourth commits in this pull request are not necessary, and can be removed if the changes they add are undesirable.